### PR TITLE
Add author validation using @AuthorExists annotation

### DIFF
--- a/src/main/java/com/epam/code/mie/library/validation/AuthorExists.java
+++ b/src/main/java/com/epam/code/mie/library/validation/AuthorExists.java
@@ -1,0 +1,17 @@
+package com.epam.code.mie.library.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = AuthorExistsValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthorExists {
+    String message() default "Author does not exist";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/epam/code/mie/library/validation/AuthorExistsValidator.java
+++ b/src/main/java/com/epam/code/mie/library/validation/AuthorExistsValidator.java
@@ -1,0 +1,23 @@
+package com.epam.code.mie.library.validation;
+
+import com.epam.code.mie.library.dtos.AuthorDto;
+import com.epam.code.mie.library.repositories.AuthorsRepository;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@RequiredArgsConstructor
+public class AuthorExistsValidator implements ConstraintValidator<AuthorExists, AuthorDto> {
+
+    private final AuthorsRepository authorsRepository;
+
+    @Override
+    public boolean isValid(AuthorDto authorDto, ConstraintValidatorContext context) {
+        if (authorDto == null) {
+            return false;
+        }
+        return authorsRepository.findByNameAndLastNameAndSecondName(
+                authorDto.name(), authorDto.lastName(), authorDto.secondName()).isPresent();
+    }
+}


### PR DESCRIPTION
This pull request addresses the following changes:

1. **Created `AuthorExists` Annotation:** Custom annotation for validating if an author exists.
2. **Created `AuthorExistsValidator` Class:** Implements `ConstraintValidator` to handle the validation logic.
3. **Updated `BookDto`:** Added `@AuthorExists` annotation to the `author` field in `BookDto`.

These changes ensure that the `author` field in `BookDto` is validated to check if the author exists in the database before adding a new book to the library.